### PR TITLE
Updated the CONFIGFILE and CACHEFILE paths

### DIFF
--- a/wp-phptidy.php
+++ b/wp-phptidy.php
@@ -108,8 +108,8 @@ $indent = true;
 ///////////// END OF DEFAULT CONFIGURATION ////////////////
 
 
-define( 'CONFIGFILE', "./.phptidy-config.php" );
-define( 'CACHEFILE', "./.phptidy-cache" );
+define( 'CONFIGFILE', __DIR__ . "/.phptidy-config.php" );
+define( 'CACHEFILE', __DIR__ . "/.phptidy-cache" );
 
 
 error_reporting( E_ALL );


### PR DESCRIPTION
This allows the script to locate the CONFIGFILE and CACHEFILE relative to the scripts location instead of relative to the location of the user when executing the script. Otherwise, executing the script from outside of the script's directory causes the script to not be able to find the two files.
